### PR TITLE
Add createdAt/updatedAt/packageState/packageUpdatedAt fields to App struct

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -24,6 +24,8 @@ type AppResource struct {
 
 type App struct {
 	Guid                     string                 `json:"guid"`
+	CreatedAt                string                 `json:"created_at"`
+	UpdatedAt                string                 `json:"updated_at"`
 	Name                     string                 `json:"name"`
 	Memory                   int                    `json:"memory"`
 	Instances                int                    `json:"instances"`
@@ -31,6 +33,7 @@ type App struct {
 	SpaceGuid                string                 `json:"space_guid"`
 	StackGuid                string                 `json:"stack_guid"`
 	State                    string                 `json:"state"`
+	PackageState             string                 `json:"package_state"`
 	Command                  string                 `json:"command"`
 	Buildpack                string                 `json:"buildpack"`
 	DetectedBuildpack        string                 `json:"detected_buildpack"`
@@ -49,6 +52,7 @@ type App struct {
 	Ports                    []int                  `json:"ports"`
 	SpaceURL                 string                 `json:"space_url"`
 	SpaceData                SpaceResource          `json:"space"`
+	PackageUpdatedAt         string                 `json:"package_updated_at"`
 	c                        *Client
 }
 
@@ -187,6 +191,8 @@ func (c *Client) ListAppsByQuery(query url.Values) ([]App, error) {
 
 		for _, app := range appResp.Resources {
 			app.Entity.Guid = app.Meta.Guid
+			app.Entity.CreatedAt = app.Meta.CreatedAt
+			app.Entity.UpdatedAt = app.Meta.UpdatedAt
 			app.Entity.SpaceData.Entity.Guid = app.Entity.SpaceData.Meta.Guid
 			app.Entity.SpaceData.Entity.OrgData.Entity.Guid = app.Entity.SpaceData.Entity.OrgData.Meta.Guid
 			app.Entity.c = c

--- a/apps_test.go
+++ b/apps_test.go
@@ -28,6 +28,8 @@ func TestListApps(t *testing.T) {
 
 		So(len(apps), ShouldEqual, 2)
 		So(apps[0].Guid, ShouldEqual, "af15c29a-6bde-4a9b-8cdf-43aa0d4b7e3c")
+		So(apps[0].CreatedAt, ShouldEqual, "2014-10-10T21:03:13+00:00")
+		So(apps[0].UpdatedAt, ShouldEqual, "2014-11-10T14:07:31+00:00")
 		So(apps[0].Name, ShouldEqual, "app-test")
 		So(apps[0].Memory, ShouldEqual, 256)
 		So(apps[0].Instances, ShouldEqual, 1)
@@ -50,6 +52,7 @@ func TestListApps(t *testing.T) {
 		So(apps[0].Environment["FOOBAR"], ShouldEqual, "QUX")
 		So(apps[0].StagingFailedReason, ShouldEqual, "")
 		So(apps[0].StagingFailedDescription, ShouldEqual, "")
+		So(apps[0].PackageState, ShouldEqual, "PENDING")
 		So(len(apps[0].Ports), ShouldEqual, 1)
 		So(apps[0].Ports[0], ShouldEqual, 8080)
 

--- a/types.go
+++ b/types.go
@@ -1,5 +1,8 @@
 package cfclient
 
 type Meta struct {
-	Guid string `json:"guid"`
+	Guid      string `json:"guid"`
+	Url       string `json:"url"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 }


### PR DESCRIPTION
**What was done**
New fields added to App struct: createdAt/updatedAt/packageState/packageUpdatedAt

The createdAt/updatedAt fields are pulled from Meta in the http response to ListAppsByQuery, and transposed into each App's Entity. Decided to do it that was as guid is being pulled in the same fashion already by the original authors.
 
**How to test**
Run app_test.go to prove it works.